### PR TITLE
Fix/privmsg

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -269,3 +269,13 @@ int Server::checkCommand(std::string command)
 	std::cout << "그런 명령어는 없어용~" << std::endl;
 	return -1;
 }
+
+int Server::getNickNameId(std::string kickUserName)
+{
+    for (int i = 0; i < MAX_EVENTS; i++)
+    {
+        if (clients[i].getNickName() == kickUserName)
+            return i;
+    }
+    return -1;
+}

--- a/Server.hpp
+++ b/Server.hpp
@@ -62,7 +62,7 @@ class Server
 
         int commandParsing(std::string input);
         int checkCommand(std::string command);
-		int getConnectClientNum() const;
+		int getNickNameId(std::string kickUserName);
 		void sendMessage(int i, std::string str);
 
 		const std::string getGenernalPass();

--- a/command/kick.cpp
+++ b/command/kick.cpp
@@ -22,7 +22,7 @@ std::string KICK(std::string input, int clientId)
         message = channelName + " :NO such channel";
         return (std::to_string(numeric) + message);
     }
-    int nickNameId = getNickNameId(clients, kickUserName);
+    int nickNameId = server.getNickNameId(kickUserName);
     if (nickNameId == -1)
     {
         numeric = ERR_USERNOTINCHANNEL;
@@ -36,14 +36,4 @@ std::string KICK(std::string input, int clientId)
     }
     return "aaaa";
 
-}
-
-int getNickNameId(Client *clients, std::string kickUserName)
-{
-    for (int i = 0; i < MAX_EVENTS; i++)
-    {
-        if (clients[i].getNickName() == kickUserName)
-            return i;
-    }
-    return -1;
 }

--- a/command/privmsg.cpp
+++ b/command/privmsg.cpp
@@ -22,7 +22,7 @@ void sendUser(int fd, std::string str)
 		message += clients[fd].getNickName();
 		message += " ";
 		message += userNick;
-        message += " :NO such nick";
+        message += " :No such nick";
 		server.sendMessage(fd, (std::to_string(numeric) + message));
         return ;
 	}
@@ -53,12 +53,24 @@ void sendChannel(int fd, std::string str, size_t chennelPoint)
 	std::string channelName = str.substr(chennelPoint + 1, spacePoint);
 
 	Channel *channel = server.findChannel(channelName);
-	int* clientStatus = channel->getClientStatus();
+	if (channel == NULL)
+    {
+		numeric = ERR_NOSUCHCHANNEL;
+		message += " ";
+		message += clients[fd].getNickName();
+		message += " ";
+		message += userNick;
+        message += " :No such channel";
+		server.sendMessage(fd, (std::to_string(numeric) + message));
+        return ;
+    }
+
+	int* clientStatus = channel->getClientStatus(); // 전체 채널 메세지 전송으로 변경예정
 
 	size_t messagePoint = str.find(':');
 	std::string chatMessage = str.substr(messagePoint);
 
-	for (int i=0; i<MAX_EVENTS; i++)
+	for (int i=0; i<MAX_EVENTS; i++) // 얘도요
 	{
 		if (clients[i].getRealName() == "")
 			continue;

--- a/command/privmsg.cpp
+++ b/command/privmsg.cpp
@@ -1,34 +1,55 @@
 #include "command.hpp"
 #include "../Channel.hpp"
 
-void PRIVMSG(int fd, std::string str)
-{
-	Server& server = Server::getInstance();
-	Client* clients = server.getClients();
+// void sendUser(int fd, std::string str)
+// {
+// 	int numeric;
+// 	std::string message;
 
+// 	Server& server = Server::getInstance();
+// 	Client* clients = server.getClients();
+
+// 	// , 단위로 split
+// 	// clients돌면서 PRIV보내기
+// }
+
+void sendChannel(int fd, std::string str, size_t chennelPoint)
+{
 	int numeric;
 	std::string message;
 
-	size_t chennelPoint = str.find('#');
+	Server& server = Server::getInstance();
+	Client* clients = server.getClients();
+
 	size_t spacePoint = str.find(' ');
 	std::string channelName = str.substr(chennelPoint + 1, spacePoint);
-	
+
 	Channel *channel = server.findChannel(channelName);
 	int* clientStatus = channel->getClientStatus();
+
+	size_t messagePoint = str.find(':');
+	std::string chatMessage = str.substr(messagePoint);
 
 	for (int i=0; i<MAX_EVENTS; i++)
 	{
 		if (clients[i].getRealName() == "")
 			continue;
-		numeric = 301;
-		size_t messagePoint = str.find(':');
-		std::string chatMessage = str.substr(messagePoint);
-		message = " " + clients[fd].getNickName() + " :" + chatMessage;
-		if (fd != i && clientStatus[i] == CONNECTED)
-		{
-			server.sendMessage(i, message);
-			// 세그폴트 발생 가능성 있음
-			// 1번 client가 disconnect된 후, 연결 안 된 채로 메세지 보내면 터질 듯 ?
-		}
+		
+		numeric = RPL_AWAY;
+		message += " PRIVMSG ";
+		message += clients[fd].getNickName();
+		message += " :";
+		message += chatMessage;
+		if (i != fd && clientStatus[i] == CONNECTED)
+			server.sendMessage(i, (std::to_string(numeric) + message));
 	}
+}
+
+void PRIVMSG(int fd, std::string str)
+{
+	size_t chennelPoint = str.find('#');
+	// if (chennelPoint == std::string::npos)
+	// 	sendUser();
+	// else
+		sendChannel(fd, str, chennelPoint);
 }

--- a/command/privmsg.cpp
+++ b/command/privmsg.cpp
@@ -1,17 +1,45 @@
 #include "command.hpp"
 #include "../Channel.hpp"
 
-// void sendUser(int fd, std::string str)
-// {
-// 	int numeric;
-// 	std::string message;
+void sendUser(int fd, std::string str)
+{
+	int numeric;
+	std::string message;
 
-// 	Server& server = Server::getInstance();
-// 	Client* clients = server.getClients();
+	Server& server = Server::getInstance();
+	Client* clients = server.getClients();
 
-// 	// , 단위로 split
-// 	// clients돌면서 PRIV보내기
-// }
+	// , 단위로 split
+	// clients돌면서 PRIV보내기
+	size_t spacePoint = str.find(' ');
+	std::string userNick = str.substr(0, spacePoint);
+
+	int nickNameId = server.getNickNameId(userNick);
+	if (nickNameId == -1)
+	{
+		numeric = ERR_NOSUCHNICK;
+		message += " ";
+		message += clients[fd].getNickName();
+		message += " ";
+		message += userNick;
+        message += " :NO such nick";
+		server.sendMessage(fd, (std::to_string(numeric) + message));
+        return ;
+	}
+
+	size_t messagePoint = str.find(':');
+	std::string chatMessage = str.substr(messagePoint);
+
+	numeric = RPL_AWAY;
+	message += " ";
+	message += clients[fd].getNickName();
+	message += " PRIVMSG ";
+	message += userNick;
+	message += " :";
+	message += chatMessage;
+	
+	server.sendMessage(nickNameId, (std::to_string(numeric) + message));
+}
 
 void sendChannel(int fd, std::string str, size_t chennelPoint)
 {
@@ -36,8 +64,10 @@ void sendChannel(int fd, std::string str, size_t chennelPoint)
 			continue;
 		
 		numeric = RPL_AWAY;
-		message += " PRIVMSG ";
+		message += " ";
 		message += clients[fd].getNickName();
+		message += " PRIVMSG #";
+		message += channelName;
 		message += " :";
 		message += chatMessage;
 		if (i != fd && clientStatus[i] == CONNECTED)
@@ -48,8 +78,8 @@ void sendChannel(int fd, std::string str, size_t chennelPoint)
 void PRIVMSG(int fd, std::string str)
 {
 	size_t chennelPoint = str.find('#');
-	// if (chennelPoint == std::string::npos)
-	// 	sendUser();
-	// else
+	if (chennelPoint == std::string::npos)
+		sendUser();
+	else
 		sendChannel(fd, str, chennelPoint);
 }


### PR DESCRIPTION
PRIVMSG #[channelName] :[text]
-> sendChannel();
채널 없을때 403

PRIVMSG [nickName] :[text]
-> sendUser();
닉네임 없을때 401

kick.cpp 안에있던 getNickNameId() 를 Server 멤버 함수로 뺐어요
